### PR TITLE
add a custom audio module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,15 +118,19 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 name = "ascii-bomb-ecs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bevy",
- "bevy_kira_audio",
  "cfg-if 1.0.0",
+ "itertools",
+ "kira",
  "once_cell",
  "parking_lot",
  "rand",
+ "rodio",
  "serde",
  "serde_json",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -430,18 +434,6 @@ dependencies = [
  "bevy_window",
  "bevy_winit",
  "ndk-glue 0.5.0",
-]
-
-[[package]]
-name = "bevy_kira_audio"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef3977fecb8f4d82b77f8c0bb415f59917c86923d5f5be688ef7099c8e9b98e"
-dependencies = [
- "anyhow",
- "bevy",
- "kira",
- "parking_lot",
 ]
 
 [[package]]
@@ -893,6 +885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
+
+[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,12 +1675,14 @@ checksum = "6e7a756bb5de5a0dea42a6f514037db18736b56c9e2313928746025721f9cca0"
 dependencies = [
  "atomic",
  "basedrop",
+ "claxon",
  "cpal",
  "getrandom",
  "hound",
  "indexmap",
  "instant",
  "lewton",
+ "minimp3",
  "rand",
  "ringbuf",
  "thiserror",
@@ -1782,6 +1797,26 @@ dependencies = [
  "foreign-types",
  "log",
  "objc",
+]
+
+[[package]]
+name = "minimp3"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985438f75febf74c392071a975a29641b420dd84431135a6e6db721de4b74372"
+dependencies = [
+ "minimp3-sys",
+ "slice-deque",
+ "thiserror",
+]
+
+[[package]]
+name = "minimp3-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2382,6 +2417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rodio"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d98f5e557b61525057e2bc142c8cd7f0e70d75dc32852309bec440e6e046bf9"
+dependencies = [
+ "cpal",
+ "hound",
+ "lewton",
+]
+
+[[package]]
 name = "ron"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2516,17 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "slice-deque"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ef6ee280cdefba6d2d0b4b78a84a1c1a3f3a4cec98c2d4231c8bc225de0f25"
+dependencies = [
+ "libc",
+ "mach",
+ "winapi",
+]
 
 [[package]]
 name = "slotmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ name = "ascii_bomb_ecs_lib"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bevy_kira_audio = { version = "0.8", features = ["ogg", "wav"] }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wasm-bindgen = "0.2"
-once_cell = "1.8.0"
 parking_lot = "0.11.2"
 cfg-if = "1.0"
+rodio = { version = "0.14", default-features = false, features = ["wav", "vorbis"] }
+anyhow = "1.0"
+itertools = "0.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { version = "0.6", default-features = false, features = [
@@ -26,10 +26,21 @@ bevy = { version = "0.6", default-features = false, features = [
     "render",
     "x11",
 ] }
+kira = "0.5.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy = { version = "0.6", default-features = false, features = [
     "bevy_winit",
     "png",
     "render",
+] }
+once_cell = "1.8.0"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "AudioBuffer",
+    "AudioBufferSourceNode",
+    "AudioContext",
+    "AudioDestinationNode",
+    "AudioParam",
+    "GainNode",
 ] }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,0 +1,101 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(target_arch = "wasm32")]
+mod web;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use bevy::{prelude::*, utils::HashMap};
+use parking_lot::RwLock;
+
+#[cfg(target_arch = "wasm32")]
+use crate::AppState;
+
+#[cfg(not(target_arch = "wasm32"))]
+use self::native::{play_queued_audio, AudioBackend, Sound};
+#[cfg(target_arch = "wasm32")]
+use self::web::{play_queued_audio, prepare_webaudio_buffers, AudioBackend, Sound};
+
+pub struct AudioPlugin;
+
+impl Plugin for AudioPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_asset::<Sound>()
+            .init_asset_loader::<SoundLoader>()
+            .init_resource::<SoundHandles>()
+            .init_resource::<Audio>()
+            .init_non_send_resource::<AudioBackend>()
+            .add_system_to_stage(CoreStage::PostUpdate, play_queued_audio.exclusive_system());
+
+        #[cfg(target_arch = "wasm32")]
+        app.add_system_set(
+            SystemSet::on_exit(AppState::Loading)
+                .with_system(prepare_webaudio_buffers.exclusive_system()),
+        );
+    }
+}
+
+#[derive(Default)]
+pub struct SoundLoader;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SoundID(usize);
+
+static SOUND_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+impl SoundID {
+    fn generate() -> Self {
+        Self(SOUND_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// Mapping between the `Sound` handles and the app-level unique IDs.
+///
+/// Needed because of the differences in how the native and the web build audio systems operate.
+/// In the native build the IDs are used to obtain the `Sound` handles again, while in the
+/// web build they are used to obtain the pre-loaded Web Audio API audio buffers.
+#[derive(Default)]
+pub struct SoundHandles(HashMap<SoundID, Handle<Sound>>);
+
+impl SoundHandles {
+    pub fn add_handle(&mut self, sound_handle: Handle<Sound>) -> SoundID {
+        let sound_id = SoundID::generate();
+        self.0.insert(sound_id, sound_handle);
+        sound_id
+    }
+}
+
+pub enum AudioCommand {
+    Play { sound_id: SoundID, looped: bool },
+    Stop,
+}
+
+/// A frontend interface resource that can be used to place audio requests from any thread.
+#[derive(Default)]
+pub struct Audio {
+    pub audio_command: RwLock<Option<AudioCommand>>,
+    pub volume_change: RwLock<Option<f32>>,
+}
+
+impl Audio {
+    pub fn play(&self, sound_id: SoundID) {
+        *self.audio_command.write() = Some(AudioCommand::Play {
+            sound_id,
+            looped: false,
+        });
+    }
+
+    pub fn play_looped(&self, sound_id: SoundID) {
+        *self.audio_command.write() = Some(AudioCommand::Play {
+            sound_id,
+            looped: true,
+        });
+    }
+
+    pub fn stop(&self) {
+        *self.audio_command.write() = Some(AudioCommand::Stop);
+    }
+
+    pub fn set_volume(&self, volume: f32) {
+        *self.volume_change.write() = Some(volume);
+    }
+}

--- a/src/audio/native.rs
+++ b/src/audio/native.rs
@@ -1,0 +1,164 @@
+use std::io::Cursor;
+
+use anyhow::Result;
+use bevy::{
+    asset::{AssetLoader, BoxedFuture, LoadContext, LoadedAsset},
+    prelude::*,
+    reflect as bevy_reflect,
+    reflect::TypeUuid,
+    utils::HashMap,
+};
+use itertools::Itertools;
+use kira::{
+    instance::{handle::InstanceHandle, InstanceLoopStart, InstanceSettings, StopInstanceSettings},
+    manager::{AudioManager, AudioManagerSettings},
+    sound::{handle::SoundHandle, Sound as KiraSound, SoundSettings},
+    Frame, Value,
+};
+use rodio::{Decoder, Source};
+
+use super::{Audio, AudioCommand, SoundHandles, SoundID, SoundLoader};
+
+#[derive(Debug, Clone, TypeUuid)]
+#[uuid = "5dc1e69a-70a3-4c99-8d8b-0d2ac17906cc"]
+pub struct Sound(KiraSound);
+
+impl AssetLoader for SoundLoader {
+    fn load<'a>(
+        &'a self,
+        bytes: &'a [u8],
+        load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let decoder = Decoder::new(Cursor::new(bytes)).unwrap();
+            let sample_rate = decoder.sample_rate();
+            let num_of_channels = decoder.channels();
+            let data = decoder.convert_samples();
+            let frames = match num_of_channels {
+                1 => data
+                    .into_iter()
+                    .map(Frame::from_mono)
+                    .collect::<Vec<Frame>>(),
+                2 => data
+                    .tuples()
+                    .map(|(left, right)| Frame::new(left, right))
+                    .collect::<Vec<Frame>>(),
+                _ => unreachable!(),
+            };
+
+            let sound = KiraSound::from_frames(sample_rate, frames, SoundSettings::default());
+
+            load_context.set_default_asset(LoadedAsset::new(Sound(sound)));
+            Ok(())
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ogg", "wav"]
+    }
+}
+
+pub struct AudioBackend {
+    sound_id_handle_map: HashMap<SoundID, SoundHandle>,
+    audio_manager: AudioManager,
+    previous_instance: Option<InstanceHandle>,
+    volume: f64,
+}
+
+impl Default for AudioBackend {
+    fn default() -> Self {
+        Self {
+            sound_id_handle_map: HashMap::default(),
+            audio_manager: AudioManager::new(AudioManagerSettings::default()).unwrap(),
+            previous_instance: None,
+            volume: 1.0,
+        }
+    }
+}
+
+pub fn play_queued_audio(
+    audio: Res<Audio>,
+    mut audio_backend: NonSendMut<AudioBackend>,
+    sound_handles: Res<SoundHandles>,
+    sounds: Res<Assets<Sound>>,
+) {
+    let mut volume_change = audio.volume_change.write();
+    if let Some(new_volume) = *volume_change {
+        let new_volume = new_volume.into();
+        audio_backend.volume = new_volume;
+
+        if let Some(ref mut instance) = &mut audio_backend.previous_instance {
+            instance.set_volume(new_volume).unwrap();
+        }
+
+        *volume_change = None;
+    }
+
+    let mut audio_command = audio.audio_command.write();
+    if let Some(command) = &*audio_command {
+        let command_successful = match command {
+            AudioCommand::Play { sound_id, looped } => {
+                if let Some(ref mut previous_instance) = audio_backend.previous_instance {
+                    previous_instance
+                        .stop(StopInstanceSettings::default())
+                        .unwrap();
+                    audio_backend.previous_instance = None;
+                }
+
+                let sound_handle =
+                    if let Some(handle) = audio_backend.sound_id_handle_map.get(sound_id) {
+                        Some(handle.clone())
+                    } else if let Some(sound) =
+                        sounds.get(sound_handles.0.get(sound_id).unwrap().clone())
+                    {
+                        let sound_handle = audio_backend
+                            .audio_manager
+                            .add_sound(sound.0.clone())
+                            .unwrap();
+
+                        audio_backend
+                            .sound_id_handle_map
+                            .insert(*sound_id, sound_handle.clone());
+
+                        Some(sound_handle)
+                    } else {
+                        // the sound has not yet been loaded
+                        None
+                    };
+
+                if let Some(mut sound_handle) = sound_handle {
+                    audio_backend.previous_instance = Some(
+                        sound_handle
+                            .play(InstanceSettings {
+                                volume: Value::Fixed(audio_backend.volume),
+                                loop_start: if *looped {
+                                    InstanceLoopStart::Custom(0.0)
+                                } else {
+                                    InstanceLoopStart::None
+                                },
+                                ..Default::default()
+                            })
+                            .unwrap(),
+                    );
+                    true
+                } else {
+                    false
+                }
+            }
+            AudioCommand::Stop => {
+                if let Some(ref mut previous_instance) = audio_backend.previous_instance {
+                    previous_instance
+                        .stop(StopInstanceSettings::default())
+                        .unwrap();
+                    audio_backend.previous_instance = None;
+                }
+
+                true
+            }
+        };
+
+        if command_successful {
+            *audio_command = None;
+        }
+    }
+}

--- a/src/audio/web.rs
+++ b/src/audio/web.rs
@@ -1,0 +1,154 @@
+use std::io::Cursor;
+
+use anyhow::Result;
+use bevy::{
+    asset::{AssetLoader, BoxedFuture, LoadContext, LoadedAsset},
+    prelude::*,
+    reflect as bevy_reflect,
+    reflect::TypeUuid,
+    utils::HashMap,
+};
+use rodio::{Decoder, Source};
+use web_sys::{AudioBuffer, AudioBufferSourceNode, AudioContext, GainNode};
+
+use super::{Audio, AudioCommand, SoundHandles, SoundID, SoundLoader};
+
+#[derive(Debug, Clone, TypeUuid)]
+#[uuid = "1fd07a42-d528-40e0-b5ff-3be79a9400b0"]
+pub struct Sound {
+    num_of_channels: u32,
+    sample_rate: f32,
+    channel_data: Vec<Vec<f32>>,
+}
+
+impl AssetLoader for SoundLoader {
+    fn load<'a>(
+        &'a self,
+        bytes: &'a [u8],
+        load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let decoder = Decoder::new(Cursor::new(bytes)).unwrap();
+            let sample_rate = decoder.sample_rate() as f32;
+            let num_of_channels = decoder.channels() as u32;
+            let mut channel_data: Vec<Vec<f32>> = vec![vec![]; num_of_channels as usize];
+            decoder
+                .convert_samples()
+                .zip((0..num_of_channels as usize).cycle())
+                .for_each(|(f, i)| channel_data[i].push(f));
+
+            load_context.set_default_asset(LoadedAsset::new(Sound {
+                num_of_channels,
+                sample_rate,
+                channel_data,
+            }));
+            Ok(())
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ogg", "wav"]
+    }
+}
+
+pub struct AudioBackend {
+    pub sound_id_audio_buffer_map: HashMap<SoundID, AudioBuffer>,
+    pub audio_context: AudioContext,
+    pub gain_node: GainNode,
+    pub previous_source: Option<AudioBufferSourceNode>,
+}
+
+impl Default for AudioBackend {
+    fn default() -> Self {
+        let audio_context = AudioContext::new().unwrap();
+        let gain_node = audio_context.create_gain().unwrap();
+        gain_node
+            .connect_with_audio_node(&audio_context.destination())
+            .unwrap();
+
+        Self {
+            audio_context,
+            gain_node,
+            sound_id_audio_buffer_map: HashMap::default(),
+            previous_source: None,
+        }
+    }
+}
+
+pub fn prepare_webaudio_buffers(
+    mut commands: Commands,
+    sound_handles: Res<SoundHandles>,
+    mut audio_backend: NonSendMut<AudioBackend>,
+    sounds: Res<Assets<Sound>>,
+) {
+    for (sound_id, sound_handle) in &sound_handles.0 {
+        let Sound {
+            num_of_channels: channels,
+            sample_rate,
+            channel_data,
+        } = sounds.get(sound_handle.clone()).unwrap();
+
+        let buffer = audio_backend
+            .audio_context
+            .create_buffer(
+                *channels,
+                channel_data.iter().fold(0, |acc, v| acc + v.len() as u32),
+                *sample_rate,
+            )
+            .unwrap();
+
+        for (i, channel) in channel_data.iter().enumerate() {
+            buffer.copy_to_channel(channel, i as i32).unwrap();
+        }
+
+        audio_backend
+            .sound_id_audio_buffer_map
+            .insert(*sound_id, buffer);
+    }
+
+    commands.remove_resource::<SoundHandles>();
+}
+
+pub fn play_queued_audio(audio: Res<Audio>, mut audio_backend: NonSendMut<AudioBackend>) {
+    let mut volume_change = audio.volume_change.write();
+    if let Some(new_volume) = &*volume_change {
+        audio_backend.gain_node.gain().set_value(*new_volume);
+        *volume_change = None;
+    }
+
+    let mut audio_command = audio.audio_command.write();
+    if let Some(command) = &*audio_command {
+        match command {
+            AudioCommand::Play { sound_id, looped } => {
+                if let Some(ref previous_source) = audio_backend.previous_source {
+                    previous_source.stop().unwrap();
+                }
+
+                let music_source = audio_backend.audio_context.create_buffer_source().unwrap();
+                music_source.set_buffer(Some(
+                    audio_backend
+                        .sound_id_audio_buffer_map
+                        .get(sound_id)
+                        .unwrap(),
+                ));
+                music_source
+                    .connect_with_audio_node(&audio_backend.gain_node)
+                    .unwrap();
+                if *looped {
+                    music_source.set_loop(true);
+                }
+                music_source.start().unwrap();
+
+                audio_backend.previous_source = Some(music_source);
+            }
+            AudioCommand::Stop => {
+                if let Some(ref previous_source) = audio_backend.previous_source {
+                    previous_source.stop().unwrap();
+                    audio_backend.previous_source = None;
+                }
+            }
+        }
+
+        *audio_command = None;
+    }
+}

--- a/src/common/systems.rs
+++ b/src/common/systems.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
-use bevy_kira_audio::Audio;
 
-use crate::common::types::InputAction;
+use crate::{audio::Audio, common::types::InputAction};
 
 use super::resources::{GameOption, GameOptionStore, InputActionStatusTracker};
 

--- a/src/game/resources.rs
+++ b/src/game/resources.rs
@@ -1,7 +1,10 @@
 use bevy::prelude::*;
-use bevy_kira_audio::AudioSource;
 
-use crate::{common::constants::COLORS, loading::resources::AssetsLoading};
+use crate::{
+    audio::{SoundHandles, SoundID},
+    common::constants::COLORS,
+    loading::resources::AssetsLoading,
+};
 
 use super::{
     components::{Penguin, Position},
@@ -172,27 +175,29 @@ impl FromWorld for GameTextures {
 }
 
 pub struct Sounds {
-    pub boom: Handle<AudioSource>,
-    pub pause: Handle<AudioSource>,
+    pub boom: SoundID,
+    pub pause: SoundID,
 }
 
 impl FromWorld for Sounds {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
 
-        let sounds = Sounds {
-            boom: asset_server.load("sounds/boom.wav"),
-            pause: asset_server.load("sounds/pause.wav"),
-        };
+        let boom_handle = asset_server.load("sounds/boom.wav");
+        let pause_handle = asset_server.load("sounds/pause.wav");
 
         if let Some(mut assets_loading) = world.get_resource_mut::<AssetsLoading>() {
             assets_loading.0.append(&mut vec![
-                sounds.boom.clone_untyped(),
-                sounds.pause.clone_untyped(),
+                boom_handle.clone_untyped(),
+                pause_handle.clone_untyped(),
             ]);
         }
 
-        sounds
+        let mut sound_handles = world.get_resource_mut::<SoundHandles>().unwrap();
+        Self {
+            boom: sound_handles.add_handle(boom_handle),
+            pause: sound_handles.add_handle(pause_handle),
+        }
     }
 }
 

--- a/src/game/systems.rs
+++ b/src/game/systems.rs
@@ -8,13 +8,13 @@ use bevy::{
     },
     utils::{HashMap, HashSet},
 };
-use bevy_kira_audio::Audio;
 use rand::{
     prelude::{IteratorRandom, SliceRandom},
     Rng,
 };
 
 use crate::{
+    audio::Audio,
     common::{
         constants::{COLORS, PIXEL_SCALE},
         resources::{Fonts, InputActionStatusTracker},
@@ -169,8 +169,7 @@ pub fn handle_user_input(
     }
 
     if inputs.is_active(InputAction::Return) && game_context.pausable {
-        audio.stop();
-        audio.play(sounds.pause.clone());
+        audio.play(sounds.pause);
         state.push(AppState::Paused).unwrap();
         inputs.clear();
     }
@@ -969,8 +968,7 @@ pub fn bomb_update(
         }
 
         if !sound_played {
-            audio.stop();
-            audio.play(sounds.boom.clone());
+            audio.play(sounds.boom);
             sound_played = true;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod battle_mode;
 mod common;
 mod game;
@@ -11,10 +12,11 @@ mod story_mode;
 mod web;
 
 use bevy::prelude::*;
-use bevy_kira_audio::AudioPlugin;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 use crate::{
+    audio::AudioPlugin,
     battle_mode::BattleModePlugin,
     common::CommonPlugin,
     game::GamePlugin,
@@ -49,7 +51,7 @@ pub enum AppState {
     SecretModeInGame,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn run() {
     let mut app = App::new();
 

--- a/src/main_menu/resources.rs
+++ b/src/main_menu/resources.rs
@@ -1,7 +1,7 @@
 use bevy::{prelude::*, utils::HashMap};
-use bevy_kira_audio::AudioSource;
 
 use crate::{
+    audio::{SoundHandles, SoundID},
     common::{constants::COLORS, resources::GameOption},
     game::types::BotDifficulty,
     loading::resources::AssetsLoading,
@@ -24,27 +24,29 @@ impl Default for MenuColors {
 }
 
 pub struct MainMenuSoundEffects {
-    pub confirm: Handle<AudioSource>,
-    pub select: Handle<AudioSource>,
+    pub confirm: SoundID,
+    pub select: SoundID,
 }
 
 impl FromWorld for MainMenuSoundEffects {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
 
-        let main_menu_sound_effects = MainMenuSoundEffects {
-            confirm: asset_server.load("sounds/confirm.wav"),
-            select: asset_server.load("sounds/select.wav"),
-        };
+        let confirm_handle = asset_server.load("sounds/confirm.wav");
+        let select_handle = asset_server.load("sounds/select.wav");
 
         if let Some(mut assets_loading) = world.get_resource_mut::<AssetsLoading>() {
             assets_loading.0.append(&mut vec![
-                main_menu_sound_effects.confirm.clone_untyped(),
-                main_menu_sound_effects.select.clone_untyped(),
+                confirm_handle.clone_untyped(),
+                select_handle.clone_untyped(),
             ]);
         }
 
-        main_menu_sound_effects
+        let mut sound_handles = world.get_resource_mut::<SoundHandles>().unwrap();
+        Self {
+            confirm: sound_handles.add_handle(confirm_handle),
+            select: sound_handles.add_handle(select_handle),
+        }
     }
 }
 

--- a/src/main_menu/systems.rs
+++ b/src/main_menu/systems.rs
@@ -1,7 +1,7 @@
 use bevy::{app::AppExit, prelude::*, utils::HashMap};
-use bevy_kira_audio::Audio;
 
 use crate::{
+    audio::Audio,
     battle_mode::BattleModeConfiguration,
     common::{
         constants::{COLORS, PIXEL_SCALE},
@@ -365,7 +365,7 @@ pub fn menu_navigation(
         }
     } else {
         if inputs.is_active(InputAction::Return) || inputs.is_active(InputAction::Space) {
-            audio.play(sounds.confirm.clone());
+            audio.play(sounds.confirm);
             match menu_state.get_enter_action() {
                 MenuAction::SwitchMenu(menu_id) => {
                     menu_state.switch_menu(menu_id);
@@ -433,12 +433,12 @@ pub fn menu_navigation(
         if inputs.is_active(InputAction::Down) {
             match menu_state.get_current_menu_mut() {
                 MenuType::SelectableItems(selectable_items) => {
-                    audio.play(sounds.select.clone());
+                    audio.play(sounds.select);
                     selectable_items.cycle_cursor_up();
                     menu_changed = true;
                 }
                 MenuType::ToggleableOptions(toggleable_options) => {
-                    audio.play(sounds.select.clone());
+                    audio.play(sounds.select);
                     toggleable_options.cycle_cursor_up();
                     menu_changed = true;
                 }
@@ -449,12 +449,12 @@ pub fn menu_navigation(
         if inputs.is_active(InputAction::Up) {
             match menu_state.get_current_menu_mut() {
                 MenuType::SelectableItems(selectable_items) => {
-                    audio.play(sounds.select.clone());
+                    audio.play(sounds.select);
                     selectable_items.cycle_cursor_down();
                     menu_changed = true;
                 }
                 MenuType::ToggleableOptions(toggleable_options) => {
-                    audio.play(sounds.select.clone());
+                    audio.play(sounds.select);
                     toggleable_options.cycle_cursor_down();
                     menu_changed = true;
                 }

--- a/src/secret_mode/resources.rs
+++ b/src/secret_mode/resources.rs
@@ -1,27 +1,29 @@
 use bevy::{core::Timer, prelude::*};
-use bevy_kira_audio::AudioSource;
 
-use crate::{game::types::Cooldown, loading::resources::AssetsLoading};
+use crate::{
+    audio::{SoundHandles, SoundID},
+    game::types::Cooldown,
+    loading::resources::AssetsLoading,
+};
 
 pub struct SecretModeMusic {
-    pub what_is_f: Handle<AudioSource>,
+    pub what_is_f: SoundID,
 }
 
 impl FromWorld for SecretModeMusic {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
 
-        let secret_mode_music = SecretModeMusic {
-            what_is_f: asset_server.load("sounds/what_is_f.ogg"),
-        };
+        let what_is_f_handle = asset_server.load("sounds/what_is_f.ogg");
 
         if let Some(mut assets_loading) = world.get_resource_mut::<AssetsLoading>() {
-            assets_loading
-                .0
-                .push(secret_mode_music.what_is_f.clone_untyped());
+            assets_loading.0.push(what_is_f_handle.clone_untyped());
         }
 
-        secret_mode_music
+        let mut sound_handles = world.get_resource_mut::<SoundHandles>().unwrap();
+        SecretModeMusic {
+            what_is_f: sound_handles.add_handle(what_is_f_handle),
+        }
     }
 }
 

--- a/src/secret_mode/systems.rs
+++ b/src/secret_mode/systems.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use bevy::{prelude::*, utils::HashSet};
-use bevy_kira_audio::Audio;
 use rand::Rng;
 
 use crate::{
+    audio::Audio,
     common::{
         constants::{COLORS, PIXEL_SCALE},
         resources::{Fonts, GameOption, GameOptionStore},
@@ -35,7 +35,7 @@ pub fn setup_secret_mode(
     // TODO: Audio will start playing only when the asset is loaded and decoded, which might be after
     // the mode is finished. However, waiting for it to load is VERY slow in debug builds, so there needs
     // to be a more granular loading wait implemented before the states that need certain assets.
-    audio.play_looped(sounds.what_is_f.clone());
+    audio.play_looped(sounds.what_is_f);
 
     const PATTERN: &str = r#"
 *              *                  *****       ********************************************

--- a/web/index.html
+++ b/web/index.html
@@ -36,8 +36,8 @@
         <img id="error-image" src="error.png">
         <p id="error-message">Sorry! An error occurred.</p>
     </div>
-    <script type="module" src="index.js"></script>
     <script src="audio_fix.js"></script>
+    <script type="module" src="index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This commit elimites usage of `bevy_kira_audio` in favor of a custom
solution that enables using preloaded audio buffers in the web build in
order to fix sound stuttering on low powered devices (https://github.com/aleksa2808/ascii-bomb-ecs/issues/15). In the native
build `kira` is now used directly.